### PR TITLE
DSTIKE ESP32 Watch DevKit(TFT) setRotation problem

### DIFF
--- a/Arduino_ST7789.cpp
+++ b/Arduino_ST7789.cpp
@@ -247,13 +247,13 @@ void Arduino_ST7789::setRotation(uint8_t m) {
   case 0:
      writedata(ST7789_MADCTL_MX | ST7789_MADCTL_MY | ST7789_MADCTL_RGB);
 
-     _xstart = 0;//_colstart;
+     _xstart = _colstart;
      _ystart = 80;//_rowstart;
      break;
   case 1:
      writedata(ST7789_MADCTL_MY | ST7789_MADCTL_MV | ST7789_MADCTL_RGB);
 
-     _ystart = 0;//_colstart;
+     _ystart = _colstart;
      _xstart = 80;//_rowstart;
      break;
   case 2:

--- a/Arduino_ST7789.cpp
+++ b/Arduino_ST7789.cpp
@@ -244,17 +244,17 @@ void Arduino_ST7789::setRotation(uint8_t m) {
   writecommand(ST7789_MADCTL);
   rotation = m % 4; // can't be higher than 3
   switch (rotation) {
-   case 0:
+  case 0:
      writedata(ST7789_MADCTL_MX | ST7789_MADCTL_MY | ST7789_MADCTL_RGB);
 
-     _xstart = _colstart;
-     _ystart = _rowstart;
+     _xstart = 0;//_colstart;
+     _ystart = 80;//_rowstart;
      break;
-   case 1:
+  case 1:
      writedata(ST7789_MADCTL_MY | ST7789_MADCTL_MV | ST7789_MADCTL_RGB);
 
-     _ystart = _colstart;
-     _xstart = _rowstart;
+     _ystart = 0;//_colstart;
+     _xstart = 80;//_rowstart;
      break;
   case 2:
      writedata(ST7789_MADCTL_RGB);


### PR DESCRIPTION
今天使用您提供的Arduino_ST7789 lib
其中的setRotation功能有問題
預設轉向為setRotation(2)、以及setRotation(3)沒問題
但轉向為setRotation(0)、setRotation(1)時，螢幕畫面會被切掉80pixels
請見下方附圖

目前我先把Arduino_ST7789.cpp做了以下更正：
251行：_ystart = _rowstart;  --> _ystart = 80;
257行：_xstart = _rowstart;  --> _xstart = 80;
已可讓setRotation(0)、setRotation(1)正常動作
但我只測試了DSTIKE ESP32 Watch DevKit(TFT)
無法幫助您測試在其他板子上的狀態

![104420142_950356448721100_3505435091627786730_n](https://user-images.githubusercontent.com/44581221/85225706-9f611f80-b405-11ea-8a9d-e2b307f6b4c5.jpg)